### PR TITLE
update epoch info field

### DIFF
--- a/contracts/native/cross_chain_manager/cosmos/cosmos_handler.go
+++ b/contracts/native/cross_chain_manager/cosmos/cosmos_handler.go
@@ -19,6 +19,7 @@ package cosmos
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
 	"github.com/ethereum/go-ethereum/contracts/native"
@@ -88,7 +89,7 @@ func (this *CosmosHandler) MakeDepositProposal(service *native.NativeContract) (
 		return nil, fmt.Errorf("Cosmos MakeDepositProposal, failed to verify cosmos header: %v", err)
 	}
 	if !bytes.Equal(myHeader.Header.ValidatorsHash, myHeader.Header.NextValidatorsHash) &&
-		uint64(myHeader.Header.Height) > info.Height {
+		myHeader.Header.Height > 0 && uint64(myHeader.Header.Height) > info.Height {
 		if err := cosmos.PutEpochSwitchInfo(service, params.SourceChainID, &cosmos.CosmosEpochSwitchInfo{
 			Height:             uint64(myHeader.Header.Height),
 			BlockHash:          myHeader.Header.Hash(),

--- a/contracts/native/header_sync/cosmos/header_sync.go
+++ b/contracts/native/header_sync/cosmos/header_sync.go
@@ -81,6 +81,10 @@ func (this *CosmosHandler) SyncGenesisHeader(native *native.NativeContract) erro
 	if err == nil && info != nil {
 		return fmt.Errorf("CosmosHandler SyncGenesisHeader, genesis header had been initialized")
 	}
+	// prevent that header height will be converted from negative to positive
+	if header.Header.Height < 0 {
+		return fmt.Errorf("CosmosHandler SyncGenesisHeader: %s", "header height invalid")
+	}
 	if err := PutEpochSwitchInfo(native, param.ChainID, &CosmosEpochSwitchInfo{
 		Height:             uint64(header.Header.Height),
 		NextValidatorsHash: header.Header.NextValidatorsHash,
@@ -114,6 +118,10 @@ func (this *CosmosHandler) SyncBlockHeader(native *native.NativeContract) error 
 		}
 		if bytes.Equal(myHeader.Header.NextValidatorsHash, myHeader.Header.ValidatorsHash) {
 			continue
+		}
+		// prevent that header height will be converted from negative to positive
+		if myHeader.Header.Height < 0 {
+			return fmt.Errorf("SyncBlockHeader, header height invalid")
 		}
 		if info.Height >= uint64(myHeader.Header.Height) {
 			log.Debugf("SyncBlockHeader, height %d is lower or equal than epoch switching height %d",

--- a/contracts/native/header_sync/okex/header_sync.go
+++ b/contracts/native/header_sync/okex/header_sync.go
@@ -181,7 +181,7 @@ func PutEpochSwitchInfo(service *native.NativeContract, chainId uint64, info *Co
 
 func notifyEpochSwitchInfo(native *native.NativeContract, chainID uint64, info *CosmosEpochSwitchInfo) error {
 	return native.AddNotify(hscommon.ABI, []string{"OKEpochSwitchInfoEvent"}, chainID, info.BlockHash.String(), info.Height,
-		info.NextValidatorsHash.String(), info.ChainID, native.ContractRef().BlockHeight())
+		info.NextValidatorsHash.String(), info.ChainID, native.ContractRef().BlockHeight().Uint64())
 }
 
 type CosmosEpochSwitchInfo struct {

--- a/contracts/native/header_sync/okex/header_sync_test.go
+++ b/contracts/native/header_sync/okex/header_sync_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021 The Zion Authors
+ * This file is part of The Zion library.
+ *
+ * The Zion is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Zion is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with The Zion.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package okex
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCosmosEpochSwitchInfo(t *testing.T) {
+	expect := &CosmosEpochSwitchInfo{
+		Height:             12,
+		BlockHash:          []byte{'1', '3', '5'},
+		NextValidatorsHash: []byte{'2', '4', '6'},
+		ChainID:            "hahaha",
+	}
+
+	blob, err := rlp.EncodeToBytes(expect)
+	assert.NoError(t, err)
+
+	got := new(CosmosEpochSwitchInfo)
+	assert.NoError(t, rlp.DecodeBytes(blob, got))
+
+	assert.Equal(t, expect, got)
+}

--- a/contracts/native/header_sync/polygon/heimdall_header_sync.go
+++ b/contracts/native/header_sync/polygon/heimdall_header_sync.go
@@ -75,8 +75,11 @@ func (h *HeimdallHandler) SyncGenesisHeader(native *native.NativeContract) (err 
 	if err == nil && info != nil {
 		return fmt.Errorf("HeimdallHandler SyncGenesisHeader, genesis header had been initialized")
 	}
+	if header.Header.Height < 0 {
+		return fmt.Errorf("HeidallHandler SyncGenesisHeader, header height invalid")
+	}
 	if err := PutEpochSwitchInfo(native, param.ChainID, &CosmosEpochSwitchInfo{
-		Height:             header.Header.Height,
+		Height:             uint64(header.Header.Height),
 		NextValidatorsHash: header.Header.NextValidatorsHash,
 		ChainID:            header.Header.ChainID,
 		BlockHash:          header.Header.Hash(),
@@ -110,7 +113,10 @@ func (h *HeimdallHandler) SyncBlockHeader(native *native.NativeContract) error {
 		if bytes.Equal(myHeader.Header.NextValidatorsHash, myHeader.Header.ValidatorsHash) {
 			continue
 		}
-		if info.Height >= myHeader.Header.Height {
+		if myHeader.Header.Height < 0 {
+			return fmt.Errorf("SyncBlockHeader, header height invalid")
+		}
+		if info.Height >= uint64(myHeader.Header.Height) {
 			log.Debugf("SyncBlockHeader, height %d is lower or equal than epoch switching height %d",
 				myHeader.Header.Height, info.Height)
 			continue
@@ -119,7 +125,7 @@ func (h *HeimdallHandler) SyncBlockHeader(native *native.NativeContract) error {
 			return fmt.Errorf("SyncBlockHeader, failed to verify header: %v", err)
 		}
 		info.NextValidatorsHash = myHeader.Header.NextValidatorsHash
-		info.Height = myHeader.Header.Height
+		info.Height = uint64(myHeader.Header.Height)
 		info.BlockHash = myHeader.Header.Hash()
 		cnt++
 	}
@@ -166,7 +172,7 @@ type CosmosEpochSwitchInfo struct {
 	// The height where validators set changed last time. Poly only accept
 	// header and proof signed by new validators. That means the header
 	// can not be lower than this height.
-	Height int64
+	Height uint64
 
 	// Hash of the block at `Height`. Poly don't save the whole header.
 	// So we can identify the content of this block by `BlockHash`.
@@ -186,7 +192,7 @@ func (m *CosmosEpochSwitchInfo) EncodeRLP(w io.Writer) error {
 
 func (m *CosmosEpochSwitchInfo) DecodeRLP(s *rlp.Stream) error {
 	var data struct {
-		Height             int64
+		Height             uint64
 		BlockHash          polygonCmn.HexBytes
 		NextValidatorsHash polygonCmn.HexBytes
 		ChainID            string


### PR DESCRIPTION
1.rlp do not support type int
2.height should be greater than zero to ensure that header height wont converted from negative to positive